### PR TITLE
Adds resource of Snapshots to Barge

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,29 @@ Size
 barge.size.all
 ```
 
+Snapshot
+---
+
+### Show all snapshots
+
+``` ruby
+barge.snapshot.all
+barge.snapshot.all(resource_type: :droplet)
+barge.snapshot.all(resource_type: :volume)
+```
+
+### Show Snapshot
+
+``` ruby
+barge.key.show(snapshot_id)
+```
+
+### Destroy Snapshot
+
+``` ruby
+barge.snapshot.destroy(snapshot_id)
+```
+
 Floating IP
 -----------
 

--- a/lib/barge/client.rb
+++ b/lib/barge/client.rb
@@ -51,6 +51,10 @@ module Barge
       @size ||= Resource::Size.new(faraday)
     end
 
+    def snapshot
+      @snapshot ||= Resource::Snapshot.new(faraday)
+    end
+
     def floating_ip
       @floating_ip ||= Resource::FloatingIP.new(faraday)
     end

--- a/lib/barge/resource.rb
+++ b/lib/barge/resource.rb
@@ -9,6 +9,7 @@ require 'barge/resource/image'
 require 'barge/resource/key'
 require 'barge/resource/region'
 require 'barge/resource/size'
+require 'barge/resource/snapshot'
 
 module Barge
   module Resource

--- a/lib/barge/resource/snapshot.rb
+++ b/lib/barge/resource/snapshot.rb
@@ -1,0 +1,20 @@
+module Barge
+  module Resource
+    class Snapshot
+      include Resource::Base
+
+      def all(options = {})
+        get('snapshots', options)
+      end
+
+      def show(snapshot_id)
+        get("snapshots/#{snapshot_id}")
+      end
+
+      def destroy(snapshot_id)
+        delete("snapshots/#{snapshot_id}")
+      end
+
+    end
+  end
+end

--- a/spec/barge/resource/snapshot_spec.rb
+++ b/spec/barge/resource/snapshot_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Barge::Resource::Snapshot do
+  include_context 'resource'
+  it_behaves_like 'a resource'
+
+  describe '#all' do
+    it 'lists all snapshots' do
+      stubbed_request =
+        stub_request!(:get, '/snapshots')
+        .to_return(body: fixture('snapshots/all'), status: 200)
+      all_snapshots = snapshot.all.snapshots
+      expect(all_snapshots)
+        .to include a_hash_including(id: '119192817')
+      expect(all_snapshots)
+        .to include a_hash_including(id: '7724db7c-e098-11e5-b522-000f53304e51')
+      expect(stubbed_request).to have_been_requested
+    end
+
+    it 'accepts an options hash' do
+      stubbed_request =
+        stub_request!(:get, '/snapshots?per_page=20&page=10&resource_type=droplet')
+        .to_return(body: fixture('snapshots/resource_type'), status: 200)
+      expect(snapshot.all(per_page: 20, page: 10, resource_type: :droplet).snapshots)
+        .to include a_hash_including(name: 'Ubuntu 13.04')
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
+  describe '#show' do
+    it 'returns information about a given snapshot' do
+      stubbed_request =
+        stub_request!(:get, '/snapshots/7724db7c-e098-11e5-b522-000f53304e51')
+        .to_return(body: fixture('snapshots/show'), status: 200)
+      expect(snapshot.show('7724db7c-e098-11e5-b522-000f53304e51').snapshot.name).to eq 'Ubuntu Foo'
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
+  describe '#destroy' do
+    it 'destroys a snapshot' do
+      stubbed_request =
+        stub_request!(:delete, '/snapshots/7724db7c-e098-11e5-b522-000f53304e51').to_return(status: 204)
+      expect(snapshot.destroy('7724db7c-e098-11e5-b522-000f53304e51').success?).to be true
+      expect(stubbed_request).to have_been_requested
+    end
+  end
+
+end

--- a/spec/fixtures/snapshots/all.json
+++ b/spec/fixtures/snapshots/all.json
@@ -1,0 +1,32 @@
+{
+  "snapshots": [
+    {
+      "id": "119192817",
+      "name": "Ubuntu 13.04",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "123",
+      "resource_type": "droplet",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    },
+    {
+      "id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "name": "Ubuntu Foo",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "volume",
+      "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/spec/fixtures/snapshots/resource_type.json
+++ b/spec/fixtures/snapshots/resource_type.json
@@ -1,0 +1,20 @@
+{
+  "snapshots": [
+    {
+      "id": "119192817",
+      "name": "Ubuntu 13.04",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "123",
+      "resource_type": "droplet",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/snapshots/show.json
+++ b/spec/fixtures/snapshots/show.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "name": "Ubuntu Foo",
+    "regions": [
+      "nyc1"
+    ],
+    "created_at": "2014-07-29T14:35:40Z",
+    "resource_type": "volume",
+    "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "min_disk_size": 10,
+    "size_gigabytes": 0.4
+  }
+}

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -10,4 +10,5 @@ shared_context 'resource' do
   let(:key) { barge.key }
   let(:region) { barge.region }
   let(:size) { barge.size }
+  let(:snapshot) { barge.snapshot }
 end


### PR DESCRIPTION
Closes #18 
- List all snapshots
- List all Droplet snapshots
- List all volume snapshots
- Retrieve existing snapshot by ID
- Delete a snapshot
- Update README
- Add specs
- Add fixtures

Documentation: https://developers.digitalocean.com/documentation/v2/#snapshots
