### PR TITLE
Implement enable-backups to droplets.

### DIFF
--- a/lib/barge/resource/droplet.rb
+++ b/lib/barge/resource/droplet.rb
@@ -83,6 +83,10 @@ module Barge
         action(droplet_id, __method__)
       end
 
+      def enable_backups(droplet_id)
+        action(droplet_id, __method__)
+      end
+
       def disable_backups(droplet_id)
         action(droplet_id, __method__)
       end

--- a/spec/barge/resource/droplet_spec.rb
+++ b/spec/barge/resource/droplet_spec.rb
@@ -285,4 +285,15 @@ describe Barge::Resource::Droplet do
       expect(stubbed_request).to have_been_requested
     end
   end
+
+  describe '#enable_backups' do
+    it 'enables backups' do
+      stubbed_request =
+        stub_request!(:post, '/droplets/221/actions')
+        .to_return(body: fixture('droplets/enable_backups'), status: 200)
+      expect(droplet.enable_backups(221).action.type).to eq 'enable_backups'
+      expect(stubbed_request.with(body: { type: :enable_backups }.to_json))
+        .to have_been_requested
+    end
+  end
 end

--- a/spec/fixtures/droplets/enable_backups.json
+++ b/spec/fixtures/droplets/enable_backups.json
@@ -1,0 +1,13 @@
+{
+  "action": {
+    "id": 36804745,
+    "status": "in-progress",
+    "type": "enable_backups",
+    "started_at": "2014-11-14T16:30:56Z",
+    "completed_at": null,
+    "resource_id": 3164450,
+    "resource_type": "droplet",
+    "region": "nyc3",
+    "region_slug": "nyc3"
+  }
+}


### PR DESCRIPTION
Currently in production we call:

droplet.send(:action, remote_id, :enable_backups)
in order to access the private action method.

Here is the documented api for enabling backups:
https://developers.digitalocean.com/documentation/v2/#enable-backups

Added a fixture json response straight out of the docs and a spec to
this method.